### PR TITLE
Login Page Media Query, Notifications Display Bug Fixed

### DIFF
--- a/public/css/media.css
+++ b/public/css/media.css
@@ -1,8 +1,8 @@
-@media(min-width:360px){
+@media(min-width:1920px){
     .title.m-b-md{
-        font-size: 2rem;
+        font-size: 5rem;
     }
     .sub-title{
-        font-size: 1rem;
+        font-size: 2rem;
     }
 }

--- a/public/css/mot.css
+++ b/public/css/mot.css
@@ -118,10 +118,10 @@ body {
     text-transform: uppercase;
     font-weight: 700;
     text-shadow: 4px 4px #226980;
-    font-size: 5rem;
+    font-size: 2rem;
 }
 .sub-title{
-    font-size:2rem;
+    font-size:1rem;
     text-transform: uppercase;
     font-weight: 500;
 }

--- a/resources/views/partials/notification.blade.php
+++ b/resources/views/partials/notification.blade.php
@@ -4,7 +4,7 @@
             {{ Auth::user()->unreadNotifications->count() }}
           </span>
         </a>
-        <div class="dropdown-menu dropdown-menu-right dropdown-menu-lg  d-md-down-none pt-0">
+        <div class="dropdown-menu dropdown-menu-right dropdown-menu-lg pt-0">
           <div class="dropdown-header bg-light">
             <strong>You have {{ Auth::user()->unreadNotifications->count() }} unread notifications</strong>
           </div>


### PR DESCRIPTION
Media query for the login page now fixed, it's default is mobile first and a media query goes for larger displays. Will do further styling on this later.

Display Notifications Bug is now fixed. d-md-down-none was causing the drop down from small - medium devices to not display at all. Removed and the bug is now fixed.